### PR TITLE
increase tolerance in pwmType

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -202,7 +202,7 @@ pwmType <- function(pwm) {
                                              byrow = FALSE,
                                              ncol = length(pwm),
                                              nrow = 4)),
-                              rep(1, length(pwm)), tolerance = 10^-5,
+                              rep(1, length(pwm)), tolerance = 10^-2,
                               check.attributes = FALSE))) {
     return("log2")
   } else if (isTRUE(all.equal(colSums(exp(as.matrix(pwm)) *
@@ -210,7 +210,7 @@ pwmType <- function(pwm) {
                                              byrow = FALSE,
                                              ncol = length(pwm),
                                              nrow = 4)),
-                              rep(1, length(pwm)), tolerance = 10^-5,
+                              rep(1, length(pwm)), tolerance = 10^-2,
                               check.attributes = FALSE))) {
     return("log")
   } else {


### PR DESCRIPTION
motifmatchr fails when using some motifs collections (e.g. https://doi.org/10.1093/nar/gkad1240 ) due to small rounding errors in the column sums of the PFM preventing `pwmType` from determining whether the motifs are PFM or PWM. While it would be possible to process the matrices to avoid this, it's actually not that trivial and unnecessary, because the problem is easily solved by increasing the tolerance in `pwmType`.
There's also no drawback in doing so, given that it's virtually impossible that all the colSums of all PWM are by chance within 0.99-1.01.